### PR TITLE
Pass back nonrecoverable auth errors when acquiring a connection

### DIFF
--- a/src/gossie/connection.go
+++ b/src/gossie/connection.go
@@ -219,8 +219,14 @@ func (cp *connectionPool) runWithRetries(t transaction, retries int) error {
 		if c == nil {
 			c, err = cp.acquire()
 			// nothing to do, cannot acquire a connection
+			// Catch and return some specific nonrecoverable errors, otherwise continue to reattempt
 			if err != nil {
-				continue
+				switch err {
+				case ErrorAuthenticationFailed, ErrorAuthorizationFailed:
+					return err
+				default:
+					continue
+				}
 			}
 		}
 


### PR DESCRIPTION
When using a cassandra cluster with _authentication_ turned on, acquiring a `newConnection` can return an authentication or authorization error. Unfortunately the `runWithRetries` method continues on errors from  `acquire` which makes sense in the case of a timeout, or other transient error, but not in the case of an authentication error, and the error returned in this case will always be `ErrorMaxRetriesReached`.

This updates the `runWithRetries` (and by extension `run`) method on a `ConnectionPool` to return the `ErrorAuthenticationFailed` or `ErrorAuthorizationFailed` errors if encountered, which will then be passed back through the `NewConnectionPool` constructor on failure.
