### PR TITLE
Fix []byte variable wrongly re-used for columns

### DIFF
--- a/src/gossie/mapping.go
+++ b/src/gossie/mapping.go
@@ -282,10 +282,18 @@ func (m *sparseMapping) Map(source interface{}) (*Row, error) {
 		if err != nil {
 			return nil, err
 		}
-		cp := make([]byte, 0, len(composite))
+		totalLen := len(columnName)
+		if len(composite) > 0 {
+			// composite columns uses one byte for the separator
+			// and two for storing the size of the data
+			totalLen += len(composite) + 3
+		}
+		cp := make([]byte, 0, totalLen)
 		if len(composite) > 0 {
 			cp = append(cp, composite...)
 			cp = append(cp, packComposite(columnName, eocEquals)...)
+		} else {
+			cp = columName
 		}
 		columnValue, err := f.marshalValue(v)
 		if err != nil {

--- a/src/gossie/mapping.go
+++ b/src/gossie/mapping.go
@@ -293,7 +293,7 @@ func (m *sparseMapping) Map(source interface{}) (*Row, error) {
 			cp = append(cp, composite...)
 			cp = append(cp, packComposite(columnName, eocEquals)...)
 		} else {
-			cp = append(cp, columnName)
+			cp = append(cp, columnName...)
 		}
 		columnValue, err := f.marshalValue(v)
 		if err != nil {

--- a/src/gossie/mapping.go
+++ b/src/gossie/mapping.go
@@ -293,7 +293,7 @@ func (m *sparseMapping) Map(source interface{}) (*Row, error) {
 			cp = append(cp, composite...)
 			cp = append(cp, packComposite(columnName, eocEquals)...)
 		} else {
-			cp = columName
+			cp = columnName
 		}
 		columnValue, err := f.marshalValue(v)
 		if err != nil {

--- a/src/gossie/mapping.go
+++ b/src/gossie/mapping.go
@@ -293,7 +293,7 @@ func (m *sparseMapping) Map(source interface{}) (*Row, error) {
 			cp = append(cp, composite...)
 			cp = append(cp, packComposite(columnName, eocEquals)...)
 		} else {
-			cp = columnName
+			cp = append(cp, columnName)
 		}
 		columnValue, err := f.marshalValue(v)
 		if err != nil {

--- a/src/gossie/mapping.go
+++ b/src/gossie/mapping.go
@@ -282,14 +282,16 @@ func (m *sparseMapping) Map(source interface{}) (*Row, error) {
 		if err != nil {
 			return nil, err
 		}
+		cp := make([]byte, 0, len(composite))
 		if len(composite) > 0 {
-			columnName = append(composite, packComposite(columnName, eocEquals)...)
+			cp = append(cp, composite...)
+			cp = append(cp, packComposite(columnName, eocEquals)...)
 		}
 		columnValue, err := f.marshalValue(v)
 		if err != nil {
 			return nil, err
 		}
-		row.Columns = append(row.Columns, &Column{Name: columnName, Value: columnValue})
+		row.Columns = append(row.Columns, &Column{Name: cp, Value: columnValue})
 	}
 
 	return row, nil


### PR DESCRIPTION
The `composite` variable shouldn't be modified as it contains the list of composite columns to prepend to the column name.
For each new column, the full name should become:
composite + columnName
This is what the line 286 was trying to achieve:

``` go
columnName = append(composite, packComposite(columnName, eocEquals)...)
```

But the composite variable in this case might end up being re-used if the length was big enough to store the columnName, meaning that in case where we had two columns for instance with the first name bigger than the second, the second name would be stored in the same variable, ending up with a crazy mix of []byte from the first and the second column name, breaking the whole line and ending up throwing an error when trying to insert to cassandra.
